### PR TITLE
Parameter names should be url encoded during oauth header generation

### DIFF
--- a/OAuth/Guts/OAuth.m
+++ b/OAuth/Guts/OAuth.m
@@ -109,11 +109,11 @@
 
 	OAHMAC_SHA1SignatureProvider *sigProvider = [[OAHMAC_SHA1SignatureProvider alloc] init];
 	
-	// If there were any params, URLencode them.
+	// If there were any params, URLencode them. Also URLencode their keys.
 	NSMutableDictionary *_params = [NSMutableDictionary dictionaryWithCapacity:[params count]];
 	if (params) {
 		for (NSString *key in [params allKeys]) {
-			[_params setObject:[[params objectForKey:key] encodedURLParameterString] forKey:key];
+			[_params setObject:[[params objectForKey:key] encodedURLParameterString] forKey: [key encodedURLParameterString]];
 		}
 	}
     


### PR DESCRIPTION
The spec (Oauth 1.0) says that both the name and value of a parameter should be URL encoded prior to normalization during signature generation.  See here: http://tools.ietf.org/html/rfc5849#section-3.4.1.3.2

There's an interactive example here: http://hueniverse.com/2008/10/beginners-guide-to-oauth-part-iv-signing-requests/
